### PR TITLE
Fix node-udp-proxy URL to use HTTP instead of SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "~4.11.2",
-    "udp-proxy": "git+ssh://git@github.com/aestek/node-udp-proxy.git",
+    "udp-proxy": "git+https://github.com/aestek/node-udp-proxy.git",
     "socket.io": "~1.3.3",
     "basic-auth-connect": "~1.0.0",
     "ejs": "~2.3.1"


### PR DESCRIPTION
SSH doesn't work without write access to the repository, causing the installation to fail, so this should be using HTTP.
